### PR TITLE
lxml version up

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'Django>1.5',
         'South>=1.0',
-        'lxml==3.3.4',
+        'lxml>=3.3.4',
         'django-webtest==1.7.7',
         'webtest==2.0.15',
     ],


### PR DESCRIPTION
Есть ли смысл привязываться к конкретной версии lxml? Под Windows еле как удалось собрать 3.4.1 (вроде). Не кроссплатформенно во общем) (хотя бы обновите версию lxml если боитесь потерять стабильность)